### PR TITLE
Add Offline Installer Setup to App Discovery Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1108,6 +1108,7 @@
 ### App Discovery Services
 
 - ❤️ [AlternativeTo](https://alternativeto.net/) - A website which lists alternatives to web-based software, desktop computer software, and mobile apps.
+- [Offline Installer Setup](https://offlineinstallersetup.com/) - A directory of offline/standalone installers for popular Windows software, listing official download sources, versions and silent-install switches.
 - [Product Hunt](https://www.producthunt.com/) - A website that lets users share and discover new products.
 
 ### Privacy and Security Guides


### PR DESCRIPTION
Adds [Offline Installer Setup](https://offlineinstallersetup.com/) to **App Discovery Services** (alphabetically, between AlternativeTo and Product Hunt).

It's a free, curated directory focused on Windows software — each entry points to the official download source and lists the current version, system requirements and silent-install switches for the full/offline installer. Free to use, no signup. It's a discovery service in the same spirit as the two entries already in this section.

Single addition, one-sentence description, no ❤️ added. Thanks for maintaining free-lunch!